### PR TITLE
Fix: Windows ESM URL scheme error

### DIFF
--- a/bin/mcp-ssh.js
+++ b/bin/mcp-ssh.js
@@ -2,11 +2,12 @@
 
 // Simple wrapper to run the main server-simple.mjs file
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Import and run the main module
-const mainModule = path.join(__dirname, '..', 'server-simple.mjs');
+// Use pathToFileURL to fix Windows ESM URL scheme error
+const mainModule = pathToFileURL(path.join(__dirname, '..', 'server-simple.mjs')).href;
 import(mainModule);


### PR DESCRIPTION
Fixes the ERR_UNSUPPORTED_ESM_URL_SCHEME error on Windows by using pathToFileURL to convert the absolute path to a valid file:// URL before importing the module. This resolves the issue where Windows paths (C:\...) were being interpreted as invalid URL protocols.